### PR TITLE
Fix bugs when authenticating request

### DIFF
--- a/backend/src/main/java/ruan/eloy/backend/config/SpringSecurityConfig.java
+++ b/backend/src/main/java/ruan/eloy/backend/config/SpringSecurityConfig.java
@@ -32,7 +32,8 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtAuthenticationEntryPoint unauthorizedHandler;
 
     @Autowired
-    public SpringSecurityConfig(StudentDetailsService studentDetailsService, JwtAuthenticationEntryPoint unauthorizedHandler) {
+    public SpringSecurityConfig(StudentDetailsService studentDetailsService,
+                                JwtAuthenticationEntryPoint unauthorizedHandler) {
         this.studentDetailsService = studentDetailsService;
         this.unauthorizedHandler = unauthorizedHandler;
     }
@@ -78,7 +79,7 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                     .and()
                 .authorizeRequests()
-                    .antMatchers("/auth/**", "/student/**")
+                    .antMatchers("/auth/**")
                         .permitAll()
                 .anyRequest()
                     .authenticated();

--- a/backend/src/main/java/ruan/eloy/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/ruan/eloy/backend/security/JwtAuthenticationFilter.java
@@ -17,19 +17,13 @@ import java.io.IOException;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
+    @Autowired
     private StudentDetailsService studentDetailsService;
 
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
-
-    @Autowired
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, StudentDetailsService studentDetailsService) {
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.studentDetailsService = studentDetailsService;
-    }
-
-    public JwtAuthenticationFilter() {}
 
     private String getTokenFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");

--- a/backend/src/main/java/ruan/eloy/backend/security/JwtTokenProvider.java
+++ b/backend/src/main/java/ruan/eloy/backend/security/JwtTokenProvider.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 
-    private static final Logger  logger= LoggerFactory.getLogger(JwtTokenProvider.class);
+    private static final Logger  logger = LoggerFactory.getLogger(JwtTokenProvider.class);
 
     @Value("${app.jwtSecret}")
     private String jwtSecret;

--- a/backend/src/main/java/ruan/eloy/backend/security/StudentDetailsService.java
+++ b/backend/src/main/java/ruan/eloy/backend/security/StudentDetailsService.java
@@ -33,6 +33,7 @@ public class StudentDetailsService implements UserDetailsService {
         return StudentPrincipal.create(student);
     }
 
+    @Transactional
     public StudentPrincipal loadUserById(Long id) {
         Student student = studentRepository.findById(id)
                 .orElseThrow(() -> new UsernameNotFoundException("Student not found with id: " + id));


### PR DESCRIPTION
**Bug description:** The JwtAuthenticationFilter was being initialized with the default constructor, so the tokenProvider and the studentDetailsService were null, at the moment of request authentication. Hence, it was happening a null point exception.

**Solution:** I removed the custom constructor method from JwtAuthenticationFilter and added the Autowired annotation to properties definition.

**Bug description:** On StudentDetailsService, when the user was going to be loaded, it was happening a LazyInitializationException.

**Solution:** That bug was happening because the student role property has the fetch type as LAZY. So, all method that needs to retrieve the student from the repository must be annotated as Transactional.